### PR TITLE
Added Focus Support

### DIFF
--- a/plugin/diminactive.vim
+++ b/plugin/diminactive.vim
@@ -327,6 +327,8 @@ fun! s:Setup(...)
       " required.
       au WinEnter,BufWinEnter * call s:Enter()
       au VimResized           * call s:SetupWindows()
+      au FocusGained          * call s:Enter()
+      au FocusLost            * call s:Leave()
     endif
   augroup END
 endfun


### PR DESCRIPTION
Enter/Leave are now triggered on FocustGained/FocusLost. This means that
in tmux when moving to a different pane all vim splits will be dimmed.
In order for this to work a terminal that supports focus events must be
used and the tmux option (focus-events on) must be set. For OSX users
iTerm2 supports focus events, in order to enable them the vim plugin
Vitality.vim is required as it sends escape codes to iTerm2 to turn on
focus reporting.
