### PR TITLE
Add Focus Support option for Issue #8 (g:diminactive_enable_focus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can enable dimming inactive window on Vim's `FocusLost` event and re-activat
 window on `FocusGained` event by adding the following line to your `.vimrc`
 (default to 0):
 
-    let g:diminactive_use_syntax = 1
+    let g:diminactive_enable_focus = 1
 
 **NOTE**: If you're using tmux, you should install the [tmux-plugins/vim-tmux-focus-events][3]
 plugin for Vim and add `set -g focus-events on` to your `~/.tmux.conf` to enable

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ disabled by default, and you can enable it using:
 
     let g:diminactive_use_syntax = 1
 
+### `FocusLost` and `FocusGained` events
+
+You can enable dimming inactive window on Vim's `FocusLost` event and re-activate
+window on `FocusGained` event by adding the following line to your `.vimrc`
+(default to 0):
+
+    let g:diminactive_use_syntax = 1
+
+**NOTE**: If you're using tmux, you should install the [tmux-plugins/vim-tmux-focus-events][3]
+plugin for Vim and add `set -g focus-events on` to your `~/.tmux.conf` to enable
+better support for Vim's `FocusLost` and `FocusGained` events when running Vim
+inside tmux.
+
 ## Commands
 
 The following commands are provided to control it:
@@ -127,3 +140,4 @@ suggestions made by joeytwiddle.
 
 [1]: https://groups.google.com/d/msg/vim_use/IJU-Vk-QLJE/xz4hjPjCRBUJ
 [2]: http://stackoverflow.com/a/12519572/15690
+[3]: https://github.com/tmux-plugins/vim-tmux-focus-events

--- a/plugin/diminactive.vim
+++ b/plugin/diminactive.vim
@@ -84,6 +84,14 @@ if !exists('g:diminactive_max_cols')
   let g:diminactive_max_cols = 256
 endif
 
+" Enable dimming inactive window on FocusLost and FocusGained event
+" NOTE: If you're using tmux, you should install the 'tmux-plugins/vim-tmux-focus-events'
+" plugin for Vim and add 'set -g focus-events on' to your ~/.tmux.conf to enable
+" better support for FocusLost/FocusGained events when running Vim inside tmux.
+if !exists('g:diminactive_enable_focus')
+  let g:diminactive_enable_focus = 0
+endif
+
 " Debug helper {{{2
 let s:counter_bufs=0
 let s:counter_wins=0
@@ -489,6 +497,11 @@ fun! s:Setup(...)
       au WinEnter   * call s:Debug('EVENT: WinEnter', {'w': winnr()}) | call s:EnterWindow()
       au VimResized * call s:Debug('EVENT: VimResized') | call s:SetupWindows()
       au TabEnter   * call s:Debug('EVENT: TabEnter') | call s:SetupWindows()
+
+      if exists('g:diminactive_enable_focus') && g:diminactive_enable_focus == 1
+        au FocusGained * call s:Enter()
+        au FocusLost * call s:Leave()
+      endif
     endif
   augroup END
   let s:debug_indent-=1


### PR DESCRIPTION
This is my follow-up to Issue #8 . I believe that an option for enabling dimming/re-activating the windows on FocusLost/FocusGained events is very important to the users, especially for those using Tmux. 

For example, I usually SSH into different servers on different tmux panes (usually 4 of them) and without an option to specify dimming/re-activating on FocusLost/FocusGained event, this plugin is quite useless in this case, because the 4 active Vim window contained inside the 4 tmux panes will not get dimmed because they are all active Vim windows.

If the user is using Vim inside tmux, he/she should install the [tmux-plugins/vim-tmux-focus-events](https://github.com/tmux-plugins/vim-tmux-focus-events) plugin for Vim and add `set -g option focus-events on` to your `~/.tmux.conf`. This is probably the reason why the author of Issue #8 had troubles setting up this option. I have tested this Pull Request thorough with Vim inside and outside tmux, inside and outside an SSH session and I can guarantee it works.

I have added the necessary option `g:diminactive_enable_focus`, along with an explanation in the `README.md` file. Please look through them when you can. I am waiting for your opinion.